### PR TITLE
Revert "Added collection property fix for blender 2.93"

### DIFF
--- a/auto_load.py
+++ b/auto_load.py
@@ -110,7 +110,7 @@ def iter_register_deps(cls):
 
 def get_dependency_from_annotation(value):
     if isinstance(value, tuple) and len(value) == 2:
-        if value[0] in (bpy.props._PropertyDeferred.PointerProperty, bpy.props._PropertyDeferred.CollectionProperty):
+        if value[0] in (bpy.props.PointerProperty, bpy.props.CollectionProperty):
             return value[1]["type"]
     return None
 


### PR DESCRIPTION
2.93 still having problems. reverting back so older versions can use. Reverts leomoon-studios/leomoon-lightstudio#40