### PR TITLE
Disable Advanced light type toggle when using EEVEE

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -159,6 +159,9 @@ class LLS_PT_Selected(bpy.types.Panel):
             row = col.row()
             # row.prop(context.scene.LLStudio, 'active_light_type', expand=True)
             row.prop(context.object.parent.LLStudio, 'type', expand=True)
+            eevee_engine = "BLENDER_EEVEE_NEXT" if bpy.app.version >= (4, 2, 0) else "BLENDER_EEVEE"
+            if context.scene.render.engine == eevee_engine:
+                row.enabled = False
             col.separator()
 
             if context.object.type == 'LIGHT':


### PR DESCRIPTION
## Summary

Greys out the Advanced/Basic light type toggle in the Selected Light panel when the render engine is EEVEE, since Advanced (mesh) lights with textures are not supported in EEVEE.

This is consistent with how the addon already defaults new lights to Basic when EEVEE is active (in `light_operators.py`), and uses the same version-aware EEVEE engine name check (`BLENDER_EEVEE` vs `BLENDER_EEVEE_NEXT` for Blender 4.2+).

Fixes #94